### PR TITLE
비밀번호 초기화시 초기화된 비밀번호를 메일로 전송한다

### DIFF
--- a/backend/src/main/kotlin/com/dclass/backend/application/UUIDBasedPasswordGenerator.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/UUIDBasedPasswordGenerator.kt
@@ -6,6 +6,6 @@ import java.util.*
 @Component
 class UUIDBasedPasswordGenerator: PasswordGenerator {
     override fun generate(): String {
-        return UUID.randomUUID().toString()
+        return UUID.randomUUID().toString().take(6)
     }
 }

--- a/backend/src/main/kotlin/com/dclass/backend/application/mail/MailService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/mail/MailService.kt
@@ -1,9 +1,11 @@
 package com.dclass.backend.application.mail
 
+import com.dclass.backend.domain.user.PasswordResetEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
 import org.thymeleaf.context.Context
 import org.thymeleaf.spring6.ISpringTemplateEngine
 
@@ -22,6 +24,25 @@ class MailService(
                 email,
                 "메일 인증 코드를 발송해 드립니다. ",
                 templateEngine.process("mail/email-authentication.html", context)
+            )
+        }
+
+    @TransactionalEventListener
+    fun sendPasswordResetMail(event: PasswordResetEvent) =
+        CoroutineScope(Dispatchers.IO).launch {
+            val context = Context().apply {
+                setVariables(
+                    mapOf(
+                        "name" to event.name,
+                        "password" to event.password
+                    )
+                )
+            }
+
+            mailSender.send(
+                event.email,
+                "${event.name}님, 임시 비밀번호를 발송해 드립니다.",
+                templateEngine.process("mail/password-reset.html", context)
             )
         }
 }

--- a/backend/src/main/kotlin/com/dclass/backend/infra/S3Client.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/infra/S3Client.kt
@@ -1,0 +1,18 @@
+package com.dclass.backend.infra
+
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.sdk.kotlin.services.s3.S3Client
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class S3Configuration(private val awsProperties: AwsProperties) {
+    @Bean(destroyMethod = "close")
+    fun s3Client() = S3Client {
+        region = "ap-northeast-2"
+        credentialsProvider = StaticCredentialsProvider {
+            accessKeyId = awsProperties.accessKey
+            secretAccessKey = awsProperties.secretKey
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/dclass/backend/infra/SesClient.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/infra/SesClient.kt
@@ -1,0 +1,19 @@
+package com.dclass.backend.infra
+
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.sdk.kotlin.services.ses.SesClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class SesConfiguration(private val awsProperties: AwsProperties) {
+    @Bean(destroyMethod = "close")
+    fun sesClient() = SesClient {
+        region = "ap-northeast-2"
+        credentialsProvider = StaticCredentialsProvider {
+            accessKeyId = awsProperties.accessKey
+            secretAccessKey = awsProperties.secretKey
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/dclass/backend/infra/mail/AwsMailSender.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/infra/mail/AwsMailSender.kt
@@ -1,24 +1,14 @@
 package com.dclass.backend.infra.mail
 
-import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.services.ses.SesClient
 import aws.sdk.kotlin.services.ses.model.*
 import com.dclass.backend.application.mail.MailSender
-import com.dclass.backend.infra.AwsProperties
 import org.springframework.stereotype.Component
 
 @Component
 class AwsMailSender(
-    private val awsProperties: AwsProperties
+    private val client: SesClient
 ) : MailSender {
-
-    private val client: SesClient = SesClient {
-        region = "ap-northeast-2"
-        credentialsProvider = StaticCredentialsProvider {
-            accessKeyId = awsProperties.accessKey
-            secretAccessKey = awsProperties.secretKey
-        }
-    }
 
     override suspend fun send(toAddress: String, subjectVal: String, bodyHtml: String) {
         val destinationOb = Destination {
@@ -48,9 +38,7 @@ class AwsMailSender(
             source = "devbelly@naver.com"
         }
 
-        client.use {
-            println("Attempting to send an email through Amazon SES using the AWS SDK for Kotlin...")
-            it.sendEmail(emailRequest)
-        }
+        println("Attempting to send an email through Amazon SES using the AWS SDK for Kotlin...")
+        client.sendEmail(emailRequest)
     }
 }

--- a/backend/src/main/kotlin/com/dclass/backend/infra/s3/AwsPresigner.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/infra/s3/AwsPresigner.kt
@@ -1,30 +1,20 @@
 package com.dclass.backend.infra.s3
 
-import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.GetObjectRequest
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.sdk.kotlin.services.s3.presigners.presignGetObject
 import aws.sdk.kotlin.services.s3.presigners.presignPutObject
-import com.dclass.backend.infra.AwsProperties
 import org.springframework.stereotype.Component
 import kotlin.time.Duration.Companion.minutes
 
 @Component
 class AwsPresigner(
-    private val properties: AwsProperties,
-    private val s3Properties: AwsS3Properties
+    private val s3Properties: AwsS3Properties,
+    private val client: S3Client
 ) {
     companion object {
         const val POST_IMAGE_FOLDER = "post-image"
-    }
-
-    private val client = S3Client {
-        region = s3Properties.region
-        credentialsProvider = StaticCredentialsProvider {
-            accessKeyId = properties.accessKey
-            secretAccessKey = properties.secretKey
-        }
     }
 
     suspend fun getPostObjectPresigned(keyName: String): String {

--- a/backend/src/main/resources/templates/mail/password-reset.html
+++ b/backend/src/main/resources/templates/mail/password-reset.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns:th="http://www.w3.org/1999/xhtml">
+<head>
+  <title>email</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<div style="display: flex; justify-content: center; align-items: center; min-height: 100vh;">
+  <div
+      style="background-color: rgb(255, 255, 255); padding: 1rem; border-radius: 0.5rem; border: 1px solid rgb(229, 231, 235); display: flex; flex-direction: column; gap: 0.5rem; width: 100%; max-width: 20rem;">
+    <h1 style="font-size: 1.25rem; font-weight: bold;">Password Reset</h1>
+    <p style="font-size: 0.875rem;">Please verify the password sent to your email:</p>
+    <span th:text="${password}"></span>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
#### Summary
- 비밀번호 초기화 시 메일을 전송한다


#### Description
- `clinet.use`를 사용하면 메서드 호출이 끝난 후 `httpclientEngine` 리소스가 정리되어 이후 호출이 제대로 되지 않습니다
- 전역적으로 사용하도록 변경해 스프링 컨텍스트 종료시 같이 종료되도록 변경했습니다