### PR TITLE
전공 및 부전공을 반환하는 비즈니스로직 구현

### DIFF
--- a/backend/src/main/kotlin/com/dclass/backend/application/UserService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/UserService.kt
@@ -3,6 +3,7 @@ package com.dclass.backend.application
 import com.dclass.backend.application.dto.EditPasswordRequest
 import com.dclass.backend.application.dto.ResetPasswordRequest
 import com.dclass.backend.application.dto.UserResponseWithDepartmentNames
+import com.dclass.backend.domain.belong.BelongRepository
 import com.dclass.backend.domain.department.DepartmentRepository
 import com.dclass.backend.domain.user.User
 import com.dclass.backend.domain.user.UserRepository
@@ -18,6 +19,7 @@ class UserService(
     private val userRepository: UserRepository,
     private val passwordGenerator: PasswordGenerator,
     private val departmentRepository: DepartmentRepository,
+    private val belongRepository: BelongRepository,
 ) {
     fun getByEmail(email: String): User {
         return userRepository.findByEmail(email) ?: throw IllegalArgumentException("회원이 존재하지 않습니다. email: $email")
@@ -37,7 +39,18 @@ class UserService(
     fun getInformation(id: Long): UserResponseWithDepartmentNames {
         val userWithDepartmentId = userRepository.findUserInfoWithDepartment(id)
         val departments = departmentRepository.findAllById(userWithDepartmentId.departmentIds).map { it.title }
-        return UserResponseWithDepartmentNames(userWithDepartmentId, departments)
+        if (departments.size == 1) {
+            return UserResponseWithDepartmentNames(userWithDepartmentId, departments[0])
+        }
+        val major = when (userWithDepartmentId.major) {
+            true -> departments[0]
+            false -> departments[1]
+        }
+        val minor = when (userWithDepartmentId.major) {
+            true -> departments[1]
+            false -> departments[0]
+        }
+        return UserResponseWithDepartmentNames(userWithDepartmentId, major, minor)
     }
 
 }

--- a/backend/src/main/kotlin/com/dclass/backend/application/dto/UserDtos.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/dto/UserDtos.kt
@@ -57,10 +57,17 @@ data class UserResponseWithDepartment(
         example = "[1, 2]"
     )
     val departmentIds: List<Long>,
+
+    @Schema(
+        description = "유저의 전공 여부",
+        example = "true"
+    )
+    val major: Boolean,
 ) {
     constructor(user: User, belong: Belong) : this(
         UserResponse(user),
-        belong.departmentIds
+        belong.departmentIds,
+        belong.major
     )
 }
 
@@ -68,14 +75,26 @@ data class UserResponseWithDepartmentNames(
     val userResponse: UserResponse,
 
     @Schema(
-        description = "유저의 소속 학과들의 이름 리스트",
-        example = "[\"컴퓨터공학과\", \"전자공학과\"]"
+        description = "유저의 전공 학과 이름",
+        example = "컴퓨터공학과"
     )
-    val departmentNames: List<String>,
+    val major: String,
+
+    @Schema(
+        description = "유저의 부전공 학과 이름",
+        example = "소프트웨어학과"
+    )
+    val minor: String? = null,
 ) {
-    constructor(user: UserResponseWithDepartment, departmentNames: List<String>) : this(
+    constructor(user: UserResponseWithDepartment, major: String, minor: String) : this(
         user.userResponse,
-        departmentNames
+        major,
+        minor,
+    )
+
+    constructor(user: UserResponseWithDepartment, major: String) : this(
+        user.userResponse,
+        major,
     )
 }
 

--- a/backend/src/main/kotlin/com/dclass/backend/domain/belong/Belong.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/belong/Belong.kt
@@ -28,8 +28,10 @@ class Belong(
     var modifiedDateTime: LocalDateTime = modifiedDateTime
         private set
 
-    val activated: Long
-        get() = _departmentIds.first()
+    val activated: Long?
+        get() = _departmentIds.firstOrNull()
+
+    var major: Boolean = true;
 
     init {
         require(departmentIds.size <= 2) { "학과는 최대 두 개까지 선택 가능합니다." }
@@ -47,6 +49,7 @@ class Belong(
 
     fun switch() {
         _departmentIds.reverse()
+        major = !major
     }
 
     private fun periodValidation(): Boolean {

--- a/backend/src/main/kotlin/com/dclass/backend/domain/belong/Belong.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/belong/Belong.kt
@@ -31,6 +31,7 @@ class Belong(
     val activated: Long?
         get() = _departmentIds.firstOrNull()
 
+    @Column(nullable = false)
     var major: Boolean = true;
 
     init {


### PR DESCRIPTION
#### Summary
전공 및 부전공을 반환하는 비즈니스로직 구현


#### Description
Belong 엔티티에서 전공 여부를 판단하는 필드를 추가.
UserService의 반환 DTO 타입을 전공 리스트가 아닌, 전공 / 부전공 필드를 따로 가지도록 변경.
