### PR TITLE
POST 댓글 수를 실제 댓글 엔티티 및 대댓글 엔티티와 동기화한다

### DIFF
--- a/backend/src/main/kotlin/com/dclass/backend/application/CommentReplyCountSyncService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/CommentReplyCountSyncService.kt
@@ -1,0 +1,18 @@
+package com.dclass.backend.application
+
+import com.dclass.backend.domain.comment.CommentRepository
+import com.dclass.backend.domain.post.PostRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class CommentReplyCountSyncService(
+    private val commentRepository: CommentRepository,
+    private val postRepository: PostRepository
+) {
+    fun sync(postId: Long) {
+        val count = commentRepository.countCommentReplyByPostId(postId)
+        val post = postRepository.findByIdOrNull(postId)
+        post?.let { it.increaseCommentReplyCount(count.toInt()) }
+    }
+}

--- a/backend/src/main/kotlin/com/dclass/backend/application/PostViewSyncService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/PostViewSyncService.kt
@@ -1,0 +1,33 @@
+package com.dclass.backend.application
+
+import com.dclass.backend.domain.post.PostRepository
+import com.dclass.backend.domain.post.getByIdOrThrow
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.ConcurrentHashMap
+
+@Transactional
+@Service
+class PostViewSyncService(
+    private val postRepository: PostRepository
+) {
+    companion object {
+        private const val VIEW_SYNC_INTERVAL = 10000L
+    }
+
+    private val productViewMap = ConcurrentHashMap<Long, Int>()
+
+    fun addView(postId: Long) {
+        productViewMap.merge(postId, 1, Int::plus)
+    }
+
+    @Scheduled(fixedDelay = VIEW_SYNC_INTERVAL)
+    fun syncView() {
+        productViewMap.forEach { (postId, viewCount) ->
+            val post = postRepository.getByIdOrThrow(postId)
+            post.increaseViewCount(viewCount)
+        }
+        productViewMap.clear()
+    }
+}

--- a/backend/src/main/kotlin/com/dclass/backend/domain/comment/CommentRepositorySupport.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/comment/CommentRepositorySupport.kt
@@ -1,6 +1,7 @@
 package com.dclass.backend.domain.comment
 
 import com.dclass.backend.application.dto.CommentWithUserResponse
+import com.dclass.backend.domain.reply.Reply
 import com.dclass.backend.domain.user.User
 import com.linecorp.kotlinjdsl.dsl.jpql.jpql
 import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
@@ -9,6 +10,7 @@ import jakarta.persistence.EntityManager
 
 interface CommentRepositorySupport {
     fun findCommentWithUserByPostId(postId: Long): List<CommentWithUserResponse>
+    fun countCommentReplyByPostId(postId: Long): Long
 }
 
 class CommentRepositoryImpl(
@@ -30,5 +32,30 @@ class CommentRepositoryImpl(
         }
 
         return em.createQuery(query, context).resultList
+    }
+
+    override fun countCommentReplyByPostId(postId: Long): Long {
+        val query = jpql {
+            val replyCount = expression(Long::class, "cnt")
+
+            val subquery = select(
+                count(entity(Reply::class))
+            ).from(
+                entity(Comment::class),
+                join(Reply::class).on(path(Comment::id).eq(path(Reply::commentId)))
+            ).where(
+                path(Comment::postId).eq(postId)
+            ).asSubquery().`as`(replyCount)
+
+            select(
+                count(path(Comment::id)).plus(subquery)
+            ).from(
+                entity(Comment::class)
+            ).where(
+                path(Comment::postId).eq(postId)
+            )
+        }
+
+        return em.createQuery(query, context).singleResult
     }
 }

--- a/backend/src/main/kotlin/com/dclass/backend/domain/post/Post.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/post/Post.kt
@@ -67,8 +67,8 @@ class Post(
         this.modifiedDateTime = LocalDateTime.now()
     }
 
-    fun increaseViewCount() {
-        postCount = postCount.increaseViewCount()
+    fun increaseViewCount(cnt: Int) {
+        postCount = postCount.increaseViewCount(cnt)
     }
 
     fun increaseCommentReplyCount(cnt : Int) {

--- a/backend/src/main/kotlin/com/dclass/backend/domain/post/Post.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/post/Post.kt
@@ -71,8 +71,8 @@ class Post(
         postCount = postCount.increaseViewCount()
     }
 
-    fun increaseReplyCount() {
-        postCount = postCount.increaseReplyCount()
+    fun increaseCommentReplyCount(cnt : Int) {
+        postCount = postCount.increaseCommentReplyCount(cnt)
     }
 
     fun increaseLikeCount() {

--- a/backend/src/main/kotlin/com/dclass/backend/domain/post/PostCount.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/post/PostCount.kt
@@ -8,7 +8,7 @@ class PostCount(
     val likeCount: Int = 0,
     val commentReplyCount: Int = 0
 ) {
-    fun increaseViewCount() = PostCount(viewCount + 1, likeCount, commentReplyCount)
+    fun increaseViewCount(cnt: Int) = PostCount(viewCount + cnt, likeCount, commentReplyCount)
     fun increaseLikeCount() = PostCount(viewCount, likeCount + 1, commentReplyCount)
     fun increaseCommentReplyCount(cnt : Int) = PostCount(viewCount, likeCount, commentReplyCount + cnt)
 }

--- a/backend/src/main/kotlin/com/dclass/backend/domain/post/PostCount.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/post/PostCount.kt
@@ -6,9 +6,9 @@ import jakarta.persistence.Embeddable
 class PostCount(
     val viewCount: Int = 0,
     val likeCount: Int = 0,
-    val replyCount: Int = 0
+    val commentReplyCount: Int = 0
 ) {
-    fun increaseViewCount() = PostCount(viewCount + 1, likeCount, replyCount)
-    fun increaseLikeCount() = PostCount(viewCount, likeCount + 1, replyCount)
-    fun increaseReplyCount() = PostCount(viewCount, likeCount, replyCount + 1)
+    fun increaseViewCount() = PostCount(viewCount + 1, likeCount, commentReplyCount)
+    fun increaseLikeCount() = PostCount(viewCount, likeCount + 1, commentReplyCount)
+    fun increaseCommentReplyCount(cnt : Int) = PostCount(viewCount, likeCount, commentReplyCount + cnt)
 }

--- a/backend/src/main/kotlin/com/dclass/backend/domain/post/PostRepository.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/post/PostRepository.kt
@@ -9,6 +9,10 @@ import com.linecorp.kotlinjdsl.render.jpql.JpqlRenderContext
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
 import jakarta.persistence.EntityManager
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.repository.findByIdOrNull
+
+fun PostRepository.getByIdOrThrow(id: Long): Post = findByIdOrNull(id)
+    ?: throw NoSuchElementException("게시글이 존재하지 않습니다. id: $id")
 
 interface PostRepository : JpaRepository<Post, Long>, PostRepositorySupport {
 }

--- a/backend/src/test/kotlin/com/dclass/backend/application/CommentIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/dclass/backend/application/CommentIntegrationTest.kt
@@ -60,5 +60,13 @@ class CommentIntegrationTest(
                 comments[1].replies.size shouldBe 2
             }
         }
+
+        When("해당 게시글의 댓글과 대댓글 수를 조회하면") {
+            val count = commentRepository.countCommentReplyByPostId(1L)
+
+            Then("댓글과 대댓글 수가 조회된다") {
+                count shouldBe 8
+            }
+        }
     }
 })

--- a/backend/src/test/kotlin/com/dclass/support/fixtures/PostFixtures.kt
+++ b/backend/src/test/kotlin/com/dclass/support/fixtures/PostFixtures.kt
@@ -34,6 +34,6 @@ fun postCount(
     return PostCount(
         viewCount = viewCount,
         likeCount = likeCount,
-        replyCount = replyCount
+        commentReplyCount = replyCount
     )
 }


### PR DESCRIPTION
#### Summary
- post 댓글 수를 실제 댓글 엔티티 및 대댓글 엔티티와 동기화한다


#### Description
- 조회수의 경우 해시맵에 저장한 후 10초 주기로 저장시키는 방식을 사용했습니다