### PR TITLE
Revert "feat: RootTab 삭제하고 로그인 후 첫페이지를 board list screen으로 변경"

### DIFF
--- a/frontend/lib/board/view/msg_board_list_screen.dart
+++ b/frontend/lib/board/view/msg_board_list_screen.dart
@@ -7,8 +7,6 @@ import 'package:frontend/board/layout/category_circle_layout.dart';
 import 'package:frontend/board/provider/board_provider.dart';
 
 class MsgBoardListScreen extends StatefulWidget {
-  static String get routeName => 'boardList';
-
   const MsgBoardListScreen({
     super.key,
   });

--- a/frontend/lib/common/view/root_tab.dart
+++ b/frontend/lib/common/view/root_tab.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/board/view/msg_board_list_screen.dart';
+import 'package:frontend/common/const/colors.dart';
+import 'package:frontend/common/layout/default_layout.dart';
+
+import '../../member/provider/member_state_notifier_provider.dart';
+
+class RootTab extends ConsumerStatefulWidget {
+  static String get routeName => 'home';
+  final int initialIndex;
+
+  const RootTab({
+    required this.initialIndex,
+    super.key,
+  });
+
+  @override
+  ConsumerState<RootTab> createState() => _RootTabState();
+}
+
+class _RootTabState extends ConsumerState<RootTab>
+    with SingleTickerProviderStateMixin {
+  late TabController controller;
+  int index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = TabController(
+        length: 4, vsync: this, initialIndex: widget.initialIndex);
+    controller.addListener(tabListener);
+    index = widget.initialIndex;
+  }
+
+  void tabListener() {
+    setState(() {
+      index = controller.index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultLayout(
+      bottomNavigationBar: BottomNavigationBar(
+        selectedItemColor: PRIMARY_COLOR,
+        unselectedItemColor: BODY_TEXT_COLOR,
+        selectedFontSize: 8.0,
+        unselectedFontSize: 10.0,
+        type: BottomNavigationBarType.fixed,
+        onTap: (int index) {
+          controller.animateTo(index);
+        },
+        currentIndex: index,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.home,
+              size: 24.0,
+            ),
+            label: '홈',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.list_alt,
+              size: 24.0,
+            ),
+            label: '게시판',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.person_outlined,
+              size: 24.0,
+            ),
+            label: '마이페이지',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.more_horiz,
+              size: 24.0,
+            ),
+            label: '더보기',
+          ),
+        ],
+        selectedLabelStyle: const TextStyle(
+          fontSize: 12.0,
+        ),
+      ),
+      child: TabBarView(
+        physics: const NeverScrollableScrollPhysics(),
+        controller: controller,
+        children: [
+          const Center(child: Text('홈')),
+          const MsgBoardListScreen(),
+          const Center(child: Text('마이페이지')),
+          Center(
+              child: ElevatedButton(
+            onPressed: () {
+              ref.read(memberStateNotifierProvider.notifier).logout();
+            },
+            child: const Text('로그아웃'),
+          )),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/common/view/root_tab.dart';
+import 'package:frontend/member/view/login_screen.dart';
+import 'package:frontend/member/view/signup_screen.dart';
 
 import 'common/provider/router_provider.dart';
 

--- a/frontend/lib/member/provider/auth_provider.dart
+++ b/frontend/lib/member/provider/auth_provider.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:frontend/board/view/msg_board_list_screen.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../common/view/root_tab.dart';
 import '../../common/view/splash_screen.dart';
 import '../model/member_model.dart';
 import '../view/login_screen.dart';
@@ -29,9 +29,14 @@ class AuthProvider extends ChangeNotifier {
 
   List<GoRoute> get routes => [
     GoRoute(
-      path: '/boardList',
-      name: MsgBoardListScreen.routeName,
-      builder: (context, state) => MsgBoardListScreen(),
+      path: '/',
+      name: RootTab.routeName,
+      builder: (context, state) {
+        final tabIndex = state.queryParameters['tabIndex'] != null
+            ? int.tryParse(state.queryParameters['tabIndex']!) ?? 0
+            : 0; // 기본적으로 첫 번째 탭을 보여준다.
+        return RootTab(initialIndex: tabIndex);
+      },
     ),
     GoRoute(
       path: '/splash',
@@ -66,7 +71,7 @@ class AuthProvider extends ChangeNotifier {
     // 1. MemberModel
     // 로그인 중이거나 현재 위치가 SplashScreen이면 홈으로 이동
     if (member is MemberModel) {
-      return loggingIn || state.location == '/splash' ? '/boardList' : null;
+      return loggingIn || state.location == '/splash' ? '/' : null;
     }
 
     // 2. MemberModelError


### PR DESCRIPTION
This reverts commit 44644bb96d2a0ff57c40c4be28c0ea885658b7b2.

#### Summary

- RootTab 삭제하고 로그인 후 첫페이지를 board list screen으로 변경


#### Description

- RootTab 삭제하고 로그인 후 첫페이지를 board list screen으로 변경