### PR TITLE
Soft delete 된 댓글 조회 로직 구현

### DIFF
--- a/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
@@ -11,6 +11,8 @@ import com.dclass.backend.domain.post.findByIdOrThrow
 import com.dclass.backend.domain.reply.ReplyRepository
 import com.dclass.backend.domain.reply.getByIdAndUserIdOrThrow
 import com.dclass.backend.domain.reply.getByIdOrThrow
+import com.dclass.backend.exception.comment.CommentException
+import com.dclass.backend.exception.comment.CommentExceptionType
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,6 +29,11 @@ class ReplyService(
 ) {
     fun create(userId: Long, request: CreateReplyRequest): ReplyResponse {
         val comment = commentRepository.getByIdOrThrow(request.commentId)
+
+        if (comment.isDeleted()) {
+            throw CommentException(CommentExceptionType.DELETED_COMMENT)
+        }
+
         val post = postRepository.findByIdOrThrow(comment.postId)
         val community = communityRepository.findByIdOrThrow(post.communityId)
 

--- a/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
@@ -43,6 +43,8 @@ class ReplyService(
             eventPublisher.publishEvent(event)
         }
 
+        comment.increaseReplyCount()
+
         return ReplyResponse(reply)
 
     }
@@ -57,7 +59,8 @@ class ReplyService(
 
         val comment = commentRepository.getByIdOrThrow(reply.commentId)
         val post = postRepository.findByIdOrThrow(comment.postId)
-        post.decreaseScrapCount()
+        post.decreaseCommentReplyCount()
+        comment.decreaseReplyCount()
 
         replyRepository.delete(reply)
     }

--- a/backend/src/main/kotlin/com/dclass/backend/application/dto/CommentDtos.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/dto/CommentDtos.kt
@@ -170,9 +170,9 @@ data class CommentWithUserResponse(
         id = comment.id,
         userInformation = UserInformation(user.name, user.email, user.nickname),
         postId = comment.postId,
-        content = comment.content,
+        content = comment.content.takeIf { !comment.isDeleted() } ?: "삭제된 댓글 입니다.",
         likeCount = comment.commentLikes,
-        deleted = comment.isDeleted(comment.id),
+        deleted = comment.isDeleted(),
         isLiked = false,
         createdAt = comment.createdDateTime
     )

--- a/backend/src/main/kotlin/com/dclass/backend/application/dto/CommentDtos.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/dto/CommentDtos.kt
@@ -149,6 +149,12 @@ data class CommentWithUserResponse(
     val likeCount: CommentLikes,
 
     @Schema(
+        description = "댓글의 삭제 여부",
+        example = "false"
+    )
+    val deleted: Boolean,
+
+    @Schema(
         description = "댓글의 좋아요 여부",
         example = "true"
     )
@@ -166,6 +172,7 @@ data class CommentWithUserResponse(
         postId = comment.postId,
         content = comment.content,
         likeCount = comment.commentLikes,
+        deleted = comment.isDeleted(comment.id),
         isLiked = false,
         createdAt = comment.createdDateTime
     )
@@ -207,6 +214,11 @@ data class CommentReplyWithUserResponse(
     )
     val likeCount: CommentLikes,
 
+    @Schema(
+        description = "댓글의 삭제 여부",
+        example = "false"
+    )
+    val deleted: Boolean,
 
     @Schema(
         description = "댓글의 좋아요 여부",
@@ -255,6 +267,7 @@ data class CommentReplyWithUserResponse(
         postId = commentWithUserResponse.postId,
         content = commentWithUserResponse.content,
         likeCount = commentWithUserResponse.likeCount,
+        deleted = commentWithUserResponse.deleted,
         isLiked = commentWithUserResponse.isLiked,
         createdAt = commentWithUserResponse.createdAt,
         replies = replies

--- a/backend/src/main/kotlin/com/dclass/backend/config/DatabaseInitializer.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/config/DatabaseInitializer.kt
@@ -828,6 +828,7 @@ class DatabaseInitializer(
                 val reply = createDummyReply(user, comment, num)
                 dummyReplies.add(reply)
                 num++
+                comment.increaseReplyCount()
 
                 val post = posts.find { it.id == comment.postId }
                 post?.increaseCommentReplyCount()

--- a/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
@@ -47,6 +47,10 @@ class Comment(
     var commentLikes: CommentLikes = commentLikes
         private set
 
+    @Column(nullable = false)
+    var replyCount: Int = 0
+        private set
+
     val likeCount: Int
         get() = commentLikes.count
 
@@ -68,4 +72,13 @@ class Comment(
     }
 
     fun isEligibleForSSE(userId: Long) = this.userId != userId
+
+    fun increaseReplyCount() {
+        replyCount++
+    }
+
+    fun decreaseReplyCount() {
+        replyCount--
+    }
+
 }

--- a/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
@@ -11,7 +11,7 @@ import org.hibernate.annotations.SQLRestriction
 import java.time.LocalDateTime
 
 @SQLDelete(sql = "update comment set deleted = true where id = ?")
-@SQLRestriction("deleted = false")
+@SQLRestriction("deleted = false OR (deleted = true AND reply_count > 0)")
 @Entity
 class Comment(
     @Column(nullable = false)

--- a/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/domain/comment/Comment.kt
@@ -64,7 +64,7 @@ class Comment(
         commentLikes.add(userId)
     }
 
-    fun isDeleted(commentId: Long) = deleted
+    fun isDeleted() = deleted
 
     fun changeContent(content: String) {
         this.content = content

--- a/backend/src/main/kotlin/com/dclass/backend/exception/comment/CommentExceptionType.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/exception/comment/CommentExceptionType.kt
@@ -11,7 +11,8 @@ enum class CommentExceptionType(
 
     FORBIDDEN_COMMENT(HttpStatus.FORBIDDEN, "C00", "댓글에 대한 권한이 없습니다."),
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "C01", "해당 댓글을 찾을 수 없습니다."),
-    SELF_LIKE(HttpStatus.BAD_REQUEST, "C02", "본인이 작성한 댓글에는 좋아요를 누를 수 없습니다.");
+    SELF_LIKE(HttpStatus.BAD_REQUEST, "C02", "본인이 작성한 댓글에는 좋아요를 누를 수 없습니다."),
+    DELETED_COMMENT(HttpStatus.BAD_REQUEST, "C03", "삭제된 댓글 입니다.");
 
     override fun httpStatus(): HttpStatus {
         return httpStatus
@@ -25,3 +26,4 @@ enum class CommentExceptionType(
         return errorMessage
     }
 }
+

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -37,6 +37,7 @@ create table comment
     post_id            bigint       not null,
     user_id            bigint       not null,
     content            varchar(255) not null,
+    reply_count        integer      not null,
     primary key (id)
 ) engine=InnoDB;
 


### PR DESCRIPTION
#### Summary
Soft delete 된 댓글 조회시 대댓글이 존재하는 댓글만 표시되도록 구현


#### Description
- Comment.kt : 대댓글 갯수 필드 및 증감 로직 추가
- CommentDtos.kt: 댓글 삭제 여부 필드 추가
- ReplyService.kt: 대댓글 작성 및 삭제 시, 댓글 필드의 replyCount 증감 로직 수행