### PR TITLE
대댓글 작성시 게시글 댓글 수가 오르지 않는 에러를 해결한다

### DIFF
--- a/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
+++ b/backend/src/main/kotlin/com/dclass/backend/application/ReplyService.kt
@@ -51,6 +51,7 @@ class ReplyService(
         }
 
         comment.increaseReplyCount()
+        post.increaseCommentReplyCount()
 
         return ReplyResponse(reply)
 


### PR DESCRIPTION
#### Summary

- 대댓글 작성시 게시글 댓글 수가 오르지 않는 에러를 해결한다
